### PR TITLE
Add Action lint for workflow validation

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,22 @@
+name: Static analytics
+
+on:
+  pull_request:
+    paths: [".github/workflows/**.yml", ".github/workflows/**.yaml"]
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint:latest


### PR DESCRIPTION
Introduce a GitHub Action to lint workflow YAML files on pull requests, ensuring better quality and adherence to standards.